### PR TITLE
Fix wrong id selection if note includes a second hackMD link

### DIFF
--- a/src/features.ts
+++ b/src/features.ts
@@ -14,7 +14,7 @@ export async function shareNote(note: JoplinNote): Promise<string> {
     let srcNoteBody = note.body
 
     if (srcNoteBody.includes(hmdMarkPrefix)) {
-        const hmdLinkRegex = /http[s]?:\/\/hackmd\.io\/@[^/]+\/([A-Za-z0-9]+)/is;
+        const hmdLinkRegex = /http[s]?:\/\/hackmd\.io\/@[^/]+\/([A-Za-z0-9]+)$/is;
         let url = hmdLinkRegex.exec(srcNoteBody)
 
         let shortExtId = url?.[1]


### PR DESCRIPTION
If a note includes an example link like so:

```markdown
This is an example for a note. You can find another not on https://hackmd.io/@user/abcdef

End of this note

 ----- 
 HackMD Note URL: https://hackmd.io/@user/fedcba
```

The added `$` ensures that the regex only works if it is at the end of the note. Currently, the id would be `abcdef`

Better would probably be to save the link into the URL parameter of the note and get rid of the regex entirely. 